### PR TITLE
Add Xperia M2 support

### DIFF
--- a/jni/offsets.c
+++ b/jni/offsets.c
@@ -249,6 +249,10 @@ struct offsets offsets[] = {
 	{ "SO-02G", "Linux version 3.4.0-perf-gf6a03f1 (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Wed Aug 5 12:06:34 2015",
 	  { (void*)FSYNC_OFFSET(0xc10e9470) },
 	  (void*)0xc10de07c, (void*)0xc10ddf6c, (void*)0xc0f56dc4, (void*)0xc10dc518 },
+	//M2 18.6.A.0.182
+	{ "D2303", "Linux version 3.4.0-gc82e70f (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Mon Aug 10 21:54:32 2015",
+	  { (void*)FSYNC_OFFSET(0xc0feaf68) },
+	  (void*)0xc0fe1fbc, (void*)0xc0fe1eac, (void*)0xc0e4aea4, (void*)0xc0fe0458 },
 	//ZR 10.7.A.0.228
 	{ "C5503", "Linux version 3.4.0-perf-gbccb33a (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Fri Jul 10 09:23:01 2015",
 	  { (void*)FSYNC_OFFSET(0xc1073ca0) },


### PR DESCRIPTION
Added offsets for the Sony Xperia M2 (D2303) on version 18.6.A.0.182.
