### PR TITLE
Add Xperia Z1 Compact, Xperia Z1, Xperia C3 and Xperia T2u support. 

### DIFF
--- a/jni/offsets.c
+++ b/jni/offsets.c
@@ -281,6 +281,10 @@ struct offsets offsets[] = {
 	{ "C6903", "Linux version 3.4.0-perf-gd26777b-00851-ga8b7b55 (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Nov 19 10:33:19 2015",
 	  { (void*)FSYNC_OFFSET(0xc10ecb90) },
 	  (void*)0xc10e17fc, (void*)0xc10e16ec, (void*)0xc0f57304, (void*)0xc10dfc98 },
+	//C3 19.4.A.0.182
+	{ "D2533", "Linux version 3.4.0+ (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Jul 2 12:32:21 2015",
+	  { (void*)FSYNC_OFFSET(0xc0fcb018) },
+	  (void*)0xc0fc207c, (void*)0xc0fc1f6c, (void*)0xc0e498e4, (void*)0xc0fc0518 },
 	//ZR 10.7.A.0.228
 	{ "C5503", "Linux version 3.4.0-perf-gbccb33a (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Fri Jul 10 09:23:01 2015",
 	  { (void*)FSYNC_OFFSET(0xc1073ca0) },

--- a/jni/offsets.c
+++ b/jni/offsets.c
@@ -277,15 +277,43 @@ struct offsets offsets[] = {
 	{ "D5503", "Linux version 3.4.0-perf-gd26777b-00851-ga8b7b55 (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Nov 19 10:33:19 2015",
 	  { (void*)FSYNC_OFFSET(0xc10ecb90) },
 	  (void*)0xc10e17fc, (void*)0xc10e16ec, (void*)0xc0f57304, (void*)0xc10dfc98 },
-	//Z1 14.6.A.1.236
+	//Z1_C6902 14.6.A.1.236
+	{ "C6902", "Linux version 3.4.0-perf-gd26777b-00851-ga8b7b55 (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Nov 19 10:33:19 2015",
+	  { (void*)FSYNC_OFFSET(0xc10ecb90) },
+	  (void*)0xc10e17fc, (void*)0xc10e16ec, (void*)0xc0f57304, (void*)0xc10dfc98 },
+	//Z1_C6903 14.6.A.1.236
 	{ "C6903", "Linux version 3.4.0-perf-gd26777b-00851-ga8b7b55 (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Nov 19 10:33:19 2015",
 	  { (void*)FSYNC_OFFSET(0xc10ecb90) },
 	  (void*)0xc10e17fc, (void*)0xc10e16ec, (void*)0xc0f57304, (void*)0xc10dfc98 },
-	//C3 19.4.A.0.182
+	//Z1_C6906 14.6.A.1.236
+	{ "C6906", "Linux version 3.4.0-perf-gd26777b-00851-ga8b7b55 (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Nov 19 10:33:19 2015",
+	  { (void*)FSYNC_OFFSET(0xc10ecb90) },
+	  (void*)0xc10e17fc, (void*)0xc10e16ec, (void*)0xc0f57304, (void*)0xc10dfc98 },
+	//Z1_C6943 14.6.A.1.236
+	{ "C6943", "Linux version 3.4.0-perf-gd26777b-00851-ga8b7b55 (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Nov 19 10:33:19 2015",
+	  { (void*)FSYNC_OFFSET(0xc10ecb90) },
+	  (void*)0xc10e17fc, (void*)0xc10e16ec, (void*)0xc0f57304, (void*)0xc10dfc98 },
+	//C3_D2502 19.4.A.0.182
+	{ "D2502", "Linux version 3.4.0+ (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Jul 2 12:32:21 2015",
+	  { (void*)FSYNC_OFFSET(0xc0fcb018) },
+	  (void*)0xc0fc207c, (void*)0xc0fc1f6c, (void*)0xc0e498e4, (void*)0xc0fc0518 },
+	//C3_D2533 19.4.A.0.182
 	{ "D2533", "Linux version 3.4.0+ (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Jul 2 12:32:21 2015",
 	  { (void*)FSYNC_OFFSET(0xc0fcb018) },
 	  (void*)0xc0fc207c, (void*)0xc0fc1f6c, (void*)0xc0e498e4, (void*)0xc0fc0518 },
-	//T2u 19.4.A.0.182
+	//T2u_D5303 19.4.A.0.182
+	{ "D5303", "Linux version 3.4.0+ (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Jul 2 12:32:21 2015",
+	  { (void*)FSYNC_OFFSET(0xc0fcb318) },
+	  (void*)0xc0fc237c, (void*)0xc0fc226c, (void*)0xc0e4a2e4, (void*)0xc0fc0818 },
+	//T2u_D5306 19.4.A.0.182
+	{ "D5306", "Linux version 3.4.0+ (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Jul 2 12:32:21 2015",
+	  { (void*)FSYNC_OFFSET(0xc0fcb318) },
+	  (void*)0xc0fc237c, (void*)0xc0fc226c, (void*)0xc0e4a2e4, (void*)0xc0fc0818 },
+	//T2u_D5316 19.4.A.0.182
+	{ "D5316", "Linux version 3.4.0+ (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Jul 2 12:32:21 2015",
+	  { (void*)FSYNC_OFFSET(0xc0fcb318) },
+	  (void*)0xc0fc237c, (void*)0xc0fc226c, (void*)0xc0e4a2e4, (void*)0xc0fc0818 },
+	//T2u_D5322 19.4.A.0.182
 	{ "D5322", "Linux version 3.4.0+ (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Jul 2 12:32:21 2015",
 	  { (void*)FSYNC_OFFSET(0xc0fcb318) },
 	  (void*)0xc0fc237c, (void*)0xc0fc226c, (void*)0xc0e4a2e4, (void*)0xc0fc0818 },

--- a/jni/offsets.c
+++ b/jni/offsets.c
@@ -273,6 +273,10 @@ struct offsets offsets[] = {
 	{ "D2305", "Linux version 3.4.0-gc82e70f (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Mon Aug 10 21:54:32 2015",
 	  { (void*)FSYNC_OFFSET(0xc0feae68) },
 	  (void*)0xc0fe1ebc, (void*)0xc0fe1dac, (void*)0xc0e4ada4, (void*)0xc0fe0358 },
+	//Z1c 14.6.A.1.236
+	{ "D5503", "Linux version 3.4.0-perf-gd26777b-00851-ga8b7b55 (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Nov 19 10:33:19 2015",
+	  { (void*)FSYNC_OFFSET(0xc10ecb90) },
+	  (void*)0xc10e17fc, (void*)0xc10e16ec, (void*)0xc0f57304, (void*)0xc10dfc98 },
 	//ZR 10.7.A.0.228
 	{ "C5503", "Linux version 3.4.0-perf-gbccb33a (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Fri Jul 10 09:23:01 2015",
 	  { (void*)FSYNC_OFFSET(0xc1073ca0) },

--- a/jni/offsets.c
+++ b/jni/offsets.c
@@ -277,6 +277,10 @@ struct offsets offsets[] = {
 	{ "D5503", "Linux version 3.4.0-perf-gd26777b-00851-ga8b7b55 (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Nov 19 10:33:19 2015",
 	  { (void*)FSYNC_OFFSET(0xc10ecb90) },
 	  (void*)0xc10e17fc, (void*)0xc10e16ec, (void*)0xc0f57304, (void*)0xc10dfc98 },
+	//Z1 14.6.A.1.236
+	{ "C6903", "Linux version 3.4.0-perf-gd26777b-00851-ga8b7b55 (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Nov 19 10:33:19 2015",
+	  { (void*)FSYNC_OFFSET(0xc10ecb90) },
+	  (void*)0xc10e17fc, (void*)0xc10e16ec, (void*)0xc0f57304, (void*)0xc10dfc98 },
 	//ZR 10.7.A.0.228
 	{ "C5503", "Linux version 3.4.0-perf-gbccb33a (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Fri Jul 10 09:23:01 2015",
 	  { (void*)FSYNC_OFFSET(0xc1073ca0) },

--- a/jni/offsets.c
+++ b/jni/offsets.c
@@ -285,6 +285,10 @@ struct offsets offsets[] = {
 	{ "D2533", "Linux version 3.4.0+ (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Jul 2 12:32:21 2015",
 	  { (void*)FSYNC_OFFSET(0xc0fcb018) },
 	  (void*)0xc0fc207c, (void*)0xc0fc1f6c, (void*)0xc0e498e4, (void*)0xc0fc0518 },
+	//T2u 19.4.A.0.182
+	{ "D5322", "Linux version 3.4.0+ (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Jul 2 12:32:21 2015",
+	  { (void*)FSYNC_OFFSET(0xc0fcb318) },
+	  (void*)0xc0fc237c, (void*)0xc0fc226c, (void*)0xc0e4a2e4, (void*)0xc0fc0818 },
 	//ZR 10.7.A.0.228
 	{ "C5503", "Linux version 3.4.0-perf-gbccb33a (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Fri Jul 10 09:23:01 2015",
 	  { (void*)FSYNC_OFFSET(0xc1073ca0) },


### PR DESCRIPTION
Add latest commits to support more Xperia family devices.
pse note: Sony created a common kernel for every single variant of each device, and in some cases, for the entire device family. However, on a very specific variant, the kernel addresses could've changed, just like happened with the EAGLE_SS (D2305) variant. If that's the case, and you know how to get the offsets, please fork, fix, and push back. 

Precompiled binaries have been attached for testing. 

[iovyroot_bins.zip](https://github.com/dosomder/iovyroot/files/332994/iovyroot_bins.zip)
