### PR TITLE
Print device name and kernel version 

### DIFF
--- a/jni/offsets.c
+++ b/jni/offsets.c
@@ -366,7 +366,7 @@ struct offsets offsets[] = {
 	  { (void*)FSYNC_OFFSET(0xc0878a30) },
 	  (void*)0xc0876b5c, (void*)0xc0876a4c, (void*)0xc07e9304, (void*)0xc0874ff8 },
 	//MediaPad T1-701u, 4.4.2 B009
-	{ "T1-701u", "Linux version 3.10.17-g7f6ac8a (jslave@wuheatculx00141) (gcc version 4.7 (GCC) ) #0 SMP PREEMPT Tue Sep 15 20:23:48 CST 2015",
+	{ "T1 7.0", "Linux version 3.10.17-g7f6ac8a (jslave@wuheatculx00141) (gcc version 4.7 (GCC) ) #0 SMP PREEMPT Tue Sep 15 20:23:48 CST 2015",
 	  { (void*)FSYNC_OFFSET(0xc087aa30) },
 	  (void*)0xc0878b5c, (void*)0xc0878a4c, (void*)0xc07eb304, (void*)0xc0876ff8 },
       //MediaPad T1-701u, 4.4.2 B101

--- a/jni/offsets.c
+++ b/jni/offsets.c
@@ -482,7 +482,7 @@ end:
 		printf("Error: Device not supported\n");
 		printf("Device name: %s\n", devname);
 		printf("Kernel version: %s\n", kernelver);
-    }
+	}
 	free(devname);
 	free(kernelver);
 	return o;

--- a/jni/offsets.c
+++ b/jni/offsets.c
@@ -467,9 +467,6 @@ struct offsets* get_offsets()
 	if(!get_kernelver(kernelver))
 		goto end;
 
-	printf("[+] Device name: %s\n", devname);
-	printf("[+] Kernel version: %s\n", kernelver);
-
 	for(i = 0; i < ARRAYELEMS(offsets); i++)
 	{
 		if(strcmp(devname, offsets[i].devname))
@@ -481,8 +478,11 @@ struct offsets* get_offsets()
 	}
 
 end:
-	if(o == NULL)
+	if(o == NULL) {
 		printf("Error: Device not supported\n");
+		printf("Device name: %s\n", devname);
+		printf("Kernel version: %s\n", kernelver);
+    }
 	free(devname);
 	free(kernelver);
 	return o;

--- a/jni/offsets.c
+++ b/jni/offsets.c
@@ -463,6 +463,9 @@ struct offsets* get_offsets()
 	if(!get_kernelver(kernelver))
 		goto end;
 
+	printf("[+] Device name: %s\n", devname);
+	printf("[+] Kernel version: %s\n", kernelver);
+
 	for(i = 0; i < ARRAYELEMS(offsets); i++)
 	{
 		if(strcmp(devname, offsets[i].devname))

--- a/jni/offsets.c
+++ b/jni/offsets.c
@@ -365,6 +365,10 @@ struct offsets offsets[] = {
 	{ "T1-701u", "Linux version 3.10.17-gbf3879f (jslave@wuheatculx00135) (gcc version 4.7 (GCC) ) #0 SMP PREEMPT Thu Jun 11 14:53:36 CST 2015",
 	  { (void*)FSYNC_OFFSET(0xc0878a30) },
 	  (void*)0xc0876b5c, (void*)0xc0876a4c, (void*)0xc07e9304, (void*)0xc0874ff8 },
+	//MediaPad T1-701u, 4.4.2 B009
+	{ "T1-701u", "Linux version 3.10.17-g7f6ac8a (jslave@wuheatculx00141) (gcc version 4.7 (GCC) ) #0 SMP PREEMPT Tue Sep 15 20:23:48 CST 2015",
+	  { (void*)FSYNC_OFFSET(0xc087aa30) },
+	  (void*)0xc0878b5c, (void*)0xc0878a4c, (void*)0xc07eb304, (void*)0xc0876ff8 },
       //MediaPad T1-701u, 4.4.2 B101
 	{ "T1-701u", "Linux version 3.10.17-gd7b8e16 (jslave@wuheatculx00129) (gcc version 4.7 (GCC) ) #0 SMP PREEMPT Sat Nov 21 12:12:27 CST 2015",
 	  { (void*)FSYNC_OFFSET(0xc087cdb0) },

--- a/jni/offsets.c
+++ b/jni/offsets.c
@@ -365,6 +365,10 @@ struct offsets offsets[] = {
 	{ "T1-701u", "Linux version 3.10.17-gbf3879f (jslave@wuheatculx00135) (gcc version 4.7 (GCC) ) #0 SMP PREEMPT Thu Jun 11 14:53:36 CST 2015",
 	  { (void*)FSYNC_OFFSET(0xc0878a30) },
 	  (void*)0xc0876b5c, (void*)0xc0876a4c, (void*)0xc07e9304, (void*)0xc0874ff8 },
+	//MediaPad T1-701u, 4.4.2 B009
+	{ "T1 7.0", "Linux version 3.10.17-g7f6ac8a (jslave@wuheatculx00141) (gcc version 4.7 (GCC) ) #0 SMP PREEMPT Tue Sep 15 20:23:48 CST 2015",
+	  { (void*)FSYNC_OFFSET(0xc087aa30) },
+	  (void*)0xc0878b5c, (void*)0xc0878a4c, (void*)0xc07eb304, (void*)0xc0876ff8 },
       //MediaPad T1-701u, 4.4.2 B101
 	{ "T1-701u", "Linux version 3.10.17-gd7b8e16 (jslave@wuheatculx00129) (gcc version 4.7 (GCC) ) #0 SMP PREEMPT Sat Nov 21 12:12:27 CST 2015",
 	  { (void*)FSYNC_OFFSET(0xc087cdb0) },
@@ -474,8 +478,11 @@ struct offsets* get_offsets()
 	}
 
 end:
-	if(o == NULL)
+	if(o == NULL) {
 		printf("Error: Device not supported\n");
+		printf("Device name: %s\n", devname);
+		printf("Kernel version: %s\n", kernelver);
+	}
 	free(devname);
 	free(kernelver);
 	return o;


### PR DESCRIPTION
for assistance in determining unsupported models.
We find this very helpful when manufacturers change ROM versions on new batches.
ALSO: Added new device kernel offsets
