### PR TITLE
Added printout of device name and kernel version when unsupported

### DIFF
--- a/jni/offsets.c
+++ b/jni/offsets.c
@@ -478,8 +478,11 @@ struct offsets* get_offsets()
 	}
 
 end:
-	if(o == NULL)
+	if(o == NULL) {
 		printf("Error: Device not supported\n");
+		printf("Device name: %s\n", devname);
+		printf("Kernel version: %s\n", kernelver);
+	}
 	free(devname);
 	free(kernelver);
 	return o;


### PR DESCRIPTION
Useful when manufacturers change kernels in a single sales batch
