### PR TITLE
Adapt to behavioral change of "inline". (Issue #39)

### DIFF
--- a/jni/getroot.c
+++ b/jni/getroot.c
@@ -5,6 +5,7 @@
 
 #include "threadinfo.h"
 #include "sid.h"
+#include "getroot.h"
 
 #define __user
 #define __kernel

--- a/jni/include/flex_array.h
+++ b/jni/include/flex_array.h
@@ -48,7 +48,11 @@ struct flex_array {
 
 void *flex_array_get(struct flex_array *fa, unsigned int element_nr);
 //safe functions for usercode
+#ifdef __GNUC_GNU_INLINE__ 
 inline unsigned int flex_array_has_element(struct flex_array* fa, unsigned int element_nr);
+#else
+extern inline unsigned int flex_array_has_element(struct flex_array* fa, unsigned int element_nr);
+#endif
 void *flex_array_get_base(struct flex_array *fa, unsigned int element_nr);
 void* flex_array_get_from_part(struct flex_array_part* part, int part_nr, struct flex_array* fa, unsigned int element_nr);
 struct flex_array_part* flex_array_get_part(struct flex_array* fa, unsigned int element_nr, int* partnr);

--- a/jni/include/getroot.h
+++ b/jni/include/getroot.h
@@ -5,7 +5,11 @@
 
 int read_at_address_pipe(void* address, void* buf, ssize_t len);
 int write_at_address_pipe(void* address, void* buf, ssize_t len);
+#ifdef __GNUC_GNU_INLINE__
 inline int writel_at_address_pipe(void* address, unsigned long val);
+#else
+extern inline int writel_at_address_pipe(void* address, unsigned long val);
+#endif
 int modify_task_cred_uc(struct thread_info* info);
 //32bit
 struct thread_info* patchaddrlimit();


### PR DESCRIPTION
Behavior change of "inline" is changed, becase NDK r13 use clang instead of gcc.
This cause build error in r13.